### PR TITLE
Chore use right namespaces for tests

### DIFF
--- a/tests/Feature/AssetQuery/Api/AssignedToQueryTest.php
+++ b/tests/Feature/AssetQuery/Api/AssignedToQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Accessories\Api;
+namespace Tests\Feature\AssetQuery\Api;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/Api/CategoryQueryTest.php
+++ b/tests/Feature/AssetQuery/Api/CategoryQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Accessories\Api;
+namespace Tests\Feature\AssetQuery\Api;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/Api/CombinedQueryTest.php
+++ b/tests/Feature/AssetQuery/Api/CombinedQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Accessories\Api;
+namespace Tests\Feature\AssetQuery\Api;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/Api/CompanyQueryTest.php
+++ b/tests/Feature/AssetQuery/Api/CompanyQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Accessories\Api;
+namespace Tests\Feature\AssetQuery\Api;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/Api/CustomFieldQueryTest.php
+++ b/tests/Feature/AssetQuery/Api/CustomFieldQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Accessories\Api;
+namespace Tests\Feature\AssetQuery\Api;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/Api/LocationQueryTest.php
+++ b/tests/Feature/AssetQuery/Api/LocationQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Accessories\Api;
+namespace Tests\Feature\AssetQuery\Api;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/Api/ManufacturerQueryTest.php
+++ b/tests/Feature/AssetQuery/Api/ManufacturerQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Accessories\Api;
+namespace Tests\Feature\AssetQuery\Api;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/Api/ModelNumberQueryTest.php
+++ b/tests/Feature/AssetQuery/Api/ModelNumberQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Accessories\Api;
+namespace Tests\Feature\AssetQuery\Api;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/Api/ModelQueryTest.php
+++ b/tests/Feature/AssetQuery/Api/ModelQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Accessories\Api;
+namespace Tests\Feature\AssetQuery\Api;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/Api/RtdLocationQueryTest.php
+++ b/tests/Feature/AssetQuery/Api/RtdLocationQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Accessories\Api;
+namespace Tests\Feature\AssetQuery\Api;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/Api/SqlInjectionQueryTest.php
+++ b/tests/Feature/AssetQuery/Api/SqlInjectionQueryTest.php
@@ -3,7 +3,7 @@
 /*
 * These testcases are trying to inject SQL through the advanced search api.
 */
-namespace Tests\Feature\Accessories\Api;
+namespace Tests\Feature\AssetQuery\Api;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/Api/StatusLabelQueryTest.php
+++ b/tests/Feature/AssetQuery/Api/StatusLabelQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Accessories\Api;
+namespace Tests\Feature\AssetQuery\Api;
 
 use App\Models\Asset;
 use App\Models\Statuslabel;

--- a/tests/Feature/AssetQuery/Api/SupplierQueryTest.php
+++ b/tests/Feature/AssetQuery/Api/SupplierQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Accessories\Api;
+namespace Tests\Feature\AssetQuery\Api;
 
 use App\Models\Asset;
 use App\Models\Supplier;

--- a/tests/Feature/AssetQuery/AssignedToQueryTest.php
+++ b/tests/Feature/AssetQuery/AssignedToQueryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Unit;
+namespace Tests\Feature\AssetQuery;
 
 use UnexpectedValueException;
 use App\Models\Asset;

--- a/tests/Feature/AssetQuery/CategoryQueryTest.php
+++ b/tests/Feature/AssetQuery/CategoryQueryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Unit;
+namespace Tests\Feature\AssetQuery;
 
 use App\Models\Category;
 use App\Models\Asset;

--- a/tests/Feature/AssetQuery/CombinedQueryTest.php
+++ b/tests/Feature/AssetQuery/CombinedQueryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Unit;
+namespace Tests\Feature\AssetQuery;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/CompanyQueryTest.php
+++ b/tests/Feature/AssetQuery/CompanyQueryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Unit;
+namespace Tests\Feature\AssetQuery;
 
 use App\Models\Company;
 use App\Models\Asset;

--- a/tests/Feature/AssetQuery/CustomFieldQueryTest.php
+++ b/tests/Feature/AssetQuery/CustomFieldQueryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Unit;
+namespace Tests\Feature\AssetQuery;
 
 use App\Models\Asset;
 use Illuminate\Database\Schema\Blueprint;

--- a/tests/Feature/AssetQuery/LocationQueryTest.php
+++ b/tests/Feature/AssetQuery/LocationQueryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Unit;
+namespace Tests\Feature\AssetQuery;
 
 use App\Models\Asset;
 use App\Models\Location;

--- a/tests/Feature/AssetQuery/ManufacturerQueryTest.php
+++ b/tests/Feature/AssetQuery/ManufacturerQueryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Unit;
+namespace Tests\Feature\AssetQuery;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/ModelNumberQueryTest.php
+++ b/tests/Feature/AssetQuery/ModelNumberQueryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Unit;
+namespace Tests\Feature\AssetQuery;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/ModelQueryTest.php
+++ b/tests/Feature/AssetQuery/ModelQueryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Unit;
+namespace Tests\Feature\AssetQuery;
 
 use App\Models\Asset;
 use App\Models\AssetModel;

--- a/tests/Feature/AssetQuery/QueryLogicTest.php
+++ b/tests/Feature/AssetQuery/QueryLogicTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Feature\AssetQuery;
 
 use Tests\TestCase;
 use App\Models\Asset;

--- a/tests/Feature/AssetQuery/RtdLocationQueryTest.php
+++ b/tests/Feature/AssetQuery/RtdLocationQueryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Unit;
+namespace Tests\Feature\AssetQuery;
 
 use App\Models\Asset;
 use App\Models\Location;

--- a/tests/Feature/AssetQuery/StatusLabelQueryTest.php
+++ b/tests/Feature/AssetQuery/StatusLabelQueryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Unit;
+namespace Tests\Feature\AssetQuery;
 
 use App\Models\Asset;
 use App\Models\Statuslabel;

--- a/tests/Feature/AssetQuery/SupplierQueryTest.php
+++ b/tests/Feature/AssetQuery/SupplierQueryTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Unit;
+namespace Tests\Feature\AssetQuery;
 
 use App\Models\Asset;
 use App\Models\Supplier;

--- a/tests/Feature/PredefinedFilter/Api/PredefinedFilterControllerTest.php
+++ b/tests/Feature/PredefinedFilter/Api/PredefinedFilterControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Api;
+namespace Tests\Feature\PredefinedFilter\Api;
 
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;


### PR DESCRIPTION
Changed namespace to the right ones. Now Featuretests won't be shown in the unittest-namespace anymore.