### PR TITLE
Now the superuser has always all permissions for the predefined filters

### DIFF
--- a/app/Livewire/Partials/AdvancedSearch/Modal.php
+++ b/app/Livewire/Partials/AdvancedSearch/Modal.php
@@ -8,6 +8,7 @@ use Livewire\Attributes\Validate;
 
 use App\Models\PredefinedFilter;
 use App\Services\PredefinedFilterService;
+use App\Models\PermissionGroup;
 
 enum FilterVisibility: string
 {
@@ -59,11 +60,19 @@ class Modal extends Component
         $this->filterId = $predefinedFilterId;
 
         $user = auth()->user();
-        $this->groupSelectOtherOptions = $user
+
+        // If the user a superuser show him all groups
+        if($user->isSuperUser()) {
+            $this->groupSelectOtherOptions = PermissionGroup::all()->pluck("id")->toArray();
+
+        } else {
+            // Show only the groups there the user is member of
+            $this->groupSelectOtherOptions = $user
             ->groups()
             ->pluck("id")
             ->toArray();
-
+        }
+ 
         if (
             $this->modalActionType === AdvancedsearchModalAction::Edit &&
             $predefinedFilterId !== null

--- a/app/Models/PredefinedFilter.php
+++ b/app/Models/PredefinedFilter.php
@@ -53,6 +53,12 @@ class PredefinedFilter extends Model
 
     public function userHasPermission(User $user, string $action): bool
     {
+
+        // Give the superuser all permissions no matter in which groups he is
+        if($user->isSuperUser()) {
+            return true;
+        }
+
         // If filter is private AND is_owner AND action != create he can do everything
         // such as create private, edit and delete
         // note the 'create' permission is only for creating public filters. 


### PR DESCRIPTION
Now the superuser has always all permissions for the predefinedfilters no matter how the groups he is member of are configured.