### PR TITLE
Feature show more in predefined filter dropdown

### DIFF
--- a/app/Http/Controllers/Api/PredefinedFilterController.php
+++ b/app/Http/Controllers/Api/PredefinedFilterController.php
@@ -133,7 +133,7 @@ class PredefinedFilterController extends Controller
     {
         $this->authorize('view.selectlists');
         
-        $filters = $this->service->selectList($request);
+        $filters = $this->service->selectList($request, true);
 
         return (new SelectlistTransformer)->transformSelectlist($filters);
     }

--- a/app/Http/Controllers/Api/PredefinedFilterController.php
+++ b/app/Http/Controllers/Api/PredefinedFilterController.php
@@ -131,10 +131,9 @@ class PredefinedFilterController extends Controller
 
     public function selectlist(Request $request)
     {
-        $this->authorize('view.selectlists');
+        $this->authorize('view', PredefinedFilter::class);
         
         $filters = $this->service->selectList($request, true);
-
         return (new SelectlistTransformer)->transformSelectlist($filters);
     }
 

--- a/app/Services/PredefinedFilterService.php
+++ b/app/Services/PredefinedFilterService.php
@@ -126,7 +126,7 @@ class PredefinedFilterService
         return $filter->delete();
     }
 
-    public function selectList(Request $request): LengthAwarePaginator
+    public function selectList(Request $request, Bool $visibilityInName = false): LengthAwarePaginator
     {
         $user = Auth::user();
 
@@ -142,7 +142,7 @@ class PredefinedFilterService
             return false;
         })->pluck('id');
 
-        $query = PredefinedFilter::select(['id', 'name'])
+        $query = PredefinedFilter::select(['id', 'name', 'is_public'])
             ->whereIn('id', $viewableFilters);
 
         if ($request->filled('search')) {
@@ -152,7 +152,7 @@ class PredefinedFilterService
         $paginated = $query->orderBy('name')->paginate(50);
 
         foreach ($paginated as $item) {
-            $item->use_text = $item->name;
+            $item->use_text = $item->name . ' (' . $this->getVisibilityAsLocalizedString($item->is_public) . ')';
         }
 
         return $paginated;
@@ -180,5 +180,9 @@ class PredefinedFilterService
             'to_add' => $toAdd,
             'to_delete' => $toDelete
         ];
+    }
+
+    private function getVisibilityAsLocalizedString(Bool $isPublic): String {
+        return $isPublic == true ? trans('general.public') : trans('general.private');
     }
 }

--- a/app/Services/PredefinedFilterService.php
+++ b/app/Services/PredefinedFilterService.php
@@ -46,7 +46,7 @@ class PredefinedFilterService
     public function getFilterById(int $id, bool $include_predefined_filter_groups = true)
     {
         $predefinedFilter = PredefinedFilter::find($id);
-        if($include_predefined_filter_groups && $predefinedFilter) {
+        if ($include_predefined_filter_groups && $predefinedFilter) {
             $permissions = $this->predefinedFilterPermissionService->getPermissionsByPredefinedFilterId($id);
             $predefinedFilter['permissions'] = $permissions;
         }
@@ -70,7 +70,7 @@ class PredefinedFilterService
         ]);
 
         // Set permissions
-        if (array_key_exists('permissions', $validated)  && count($validated['permissions']) > 0) {
+        if (array_key_exists('permissions', $validated) && count($validated['permissions']) > 0) {
             foreach ($validated['permissions'] as $permission) {
                 $permission['predefined_filter_id'] = $filter_create_response->id;
                 $this->predefinedFilterPermissionService->store($permission);
@@ -126,7 +126,7 @@ class PredefinedFilterService
         return $filter->delete();
     }
 
-    public function selectList(Request $request, Bool $visibilityInName = false): LengthAwarePaginator
+    public function selectList(Request $request, bool $visibilityInName = false): LengthAwarePaginator
     {
         $user = Auth::user();
 
@@ -146,13 +146,33 @@ class PredefinedFilterService
             ->whereIn('id', $viewableFilters);
 
         if ($request->filled('search')) {
-            $query->where('name', 'LIKE', '%' . $request->get('search') . '%');
+            $search = trim($request->get('search', ''));
+            $upper = strtoupper($search);
+
+            $privateTag = strtoupper(trans('general.private')) . ':';
+            $publicTag = strtoupper(trans('general.public')) . ':';
+
+            if (str_starts_with($upper, 'PRIVATE:') || str_starts_with($upper, $privateTag)) {
+                $query->where('is_public', 0);
+                $search = preg_replace('/^(PRIVATE:|' . preg_quote($privateTag, '/') . ')/i', '', $search);
+            } elseif (str_starts_with($upper, 'PUBLIC:') || str_starts_with($upper, $publicTag)) {
+                $query->where('is_public', 1);
+                $search = preg_replace('/^(PUBLIC:|' . preg_quote($publicTag, '/') . ')/i', '', $search);
+            }
+
+            $query->where('name', 'LIKE', '%' . trim($search) . '%');
         }
+
+
 
         $paginated = $query->orderBy('name')->paginate(50);
 
         foreach ($paginated as $item) {
-            $item->use_text = $item->name . ' (' . $this->getVisibilityAsLocalizedString($item->is_public) . ')';
+            if ($visibilityInName === true) {
+                $item->use_text = $item->name . ' (' . $this->getVisibilityAsLocalizedString($item->is_public) . ')';
+            } else {
+                $item->use_text = $item->name;
+            }
         }
 
         return $paginated;
@@ -161,20 +181,20 @@ class PredefinedFilterService
     private function syncPermissions($currentPermissions, $newPermissions): array
     {
         $toAdd = array_udiff(
-        $newPermissions,
-        $currentPermissions,
-        function ($a, $b) {
-            return $a['permission_group_id'] <=> $b['permission_group_id'];
-        }
-    );
+            $newPermissions,
+            $currentPermissions,
+            function ($a, $b) {
+                return $a['permission_group_id'] <=> $b['permission_group_id'];
+            }
+        );
 
         $toDelete = array_udiff(
-        $currentPermissions,
-        $newPermissions,
-        function ($a, $b) {
-            return $a['permission_group_id'] <=> $b['permission_group_id'];
-        }
-    );
+            $currentPermissions,
+            $newPermissions,
+            function ($a, $b) {
+                return $a['permission_group_id'] <=> $b['permission_group_id'];
+            }
+        );
 
         return [
             'to_add' => $toAdd,
@@ -182,7 +202,8 @@ class PredefinedFilterService
         ];
     }
 
-    private function getVisibilityAsLocalizedString(Bool $isPublic): String {
+    private function getVisibilityAsLocalizedString(bool $isPublic): string
+    {
         return $isPublic == true ? trans('general.public') : trans('general.private');
     }
 }

--- a/tests/Feature/PredefinedFilter/Api/PredefinedFilterControllerTest.php
+++ b/tests/Feature/PredefinedFilter/Api/PredefinedFilterControllerTest.php
@@ -23,7 +23,7 @@ class PredefinedFilterControllerTest extends TestCase
         return $g;
     }
 
-    private function linkGroupFilter(PredefinedFilter $f,  PermissionGroup $g)
+    private function linkGroupFilter(PredefinedFilter $f, PermissionGroup $g)
     {
         DB::table('predefined_filter_permissions')->insert([
             'predefined_filter_id' => $f->id,
@@ -47,13 +47,13 @@ class PredefinedFilterControllerTest extends TestCase
             ->assertOk();
     }
 
-    public function test_index_unauthenticated_gets_302() 
+    public function test_index_unauthenticated_gets_302()
     {
         $this->getJson('api/v1/predefinedFilters')->assertStatus(302);
 
     }
 
-    public function test_index_empty_returns_empty_array() 
+    public function test_index_empty_returns_empty_array()
     {
         $u = User::factory()->create();
 
@@ -66,61 +66,67 @@ class PredefinedFilterControllerTest extends TestCase
     public function test_index_lists_only_viewable_or_owned(): void
     {
         $owner = User::factory()->create();
-        $u     = User::factory()->create();
-        $g     = $this->grant($u, ['predefinedFilter.view' => '1']);
+        $u = User::factory()->create();
+        $g = $this->grant($u, ['predefinedFilter.view' => '1']);
 
         $viewable = PredefinedFilter::factory()->create([
-            'name'       => 'A Viewable',
+            'name' => 'A Viewable',
             'created_by' => $owner->id,
-            'is_public'  => 1,
+            'is_public' => 1,
         ]);
         $this->linkGroupFilter($viewable, $g);
 
         $hidden = PredefinedFilter::factory()->create([
-            'name'       => 'Z Hidden',
+            'name' => 'Z Hidden',
             'created_by' => $owner->id,
-            'is_public'  => 0,
+            'is_public' => 0,
         ]);
 
         $mine = PredefinedFilter::factory()->create([
-            'name'       => 'M My Own',
+            'name' => 'M My Own',
             'created_by' => $u->id,
-            'is_public'  => 0,
+            'is_public' => 0,
         ]);
 
         $response = $this->actingAs($u, 'api')
             ->getJson('/api/v1/predefinedFilters')
             ->assertOk()
-            ->assertJsonFragment(['id'=>$viewable->id,'name'=>'A Viewable'])
-            ->assertJsonFragment(['id'=>$mine->id,'name'=>'M My Own']);
+            ->assertJsonFragment(['id' => $viewable->id, 'name' => 'A Viewable'])
+            ->assertJsonFragment(['id' => $mine->id, 'name' => 'M My Own']);
         $this->assertCount(2, $response->json('rows'));
     }
-    
+
     public function test_index_lists_only_public_linked_or_owned(): void
     {
         $owner = User::factory()->create();
-        $user  = User::factory()->create();
+        $user = User::factory()->create();
         $g = $this->grant($user, ['predefinedFilter.view' => '1']);
 
         $viewable = PredefinedFilter::factory()->create([
-            'name'=>'Viewable Filter','created_by'=>$owner->id,'is_public'=>1,
+            'name' => 'Viewable Filter',
+            'created_by' => $owner->id,
+            'is_public' => 1,
         ]);
-        $this->linkGroupFilter($viewable,$g);
+        $this->linkGroupFilter($viewable, $g);
 
         $hidden = PredefinedFilter::factory()->create([
-            'name'=>'Hidden Filter','created_by'=>$owner->id,'is_public'=>0,
+            'name' => 'Hidden Filter',
+            'created_by' => $owner->id,
+            'is_public' => 0,
         ]);
 
         $mine = PredefinedFilter::factory()->create([
-            'name'=>'My Own','created_by'=>$user->id,'is_public'=>0,
+            'name' => 'My Own',
+            'created_by' => $user->id,
+            'is_public' => 0,
         ]);
 
-        $this->actingAs($user,'api')
+        $this->actingAs($user, 'api')
             ->getJson('/api/v1/predefinedFilters')
             ->assertOk()
-            ->assertJsonFragment(['name'=>'Viewable Filter'])
-            ->assertJsonFragment(['name'=>'My Own'])
-            ->assertJsonMissing(['name'=>'Hidden Filter']);
+            ->assertJsonFragment(['name' => 'Viewable Filter'])
+            ->assertJsonFragment(['name' => 'My Own'])
+            ->assertJsonMissing(['name' => 'Hidden Filter']);
     }
 
     //------SHOW TESTS------
@@ -128,15 +134,15 @@ class PredefinedFilterControllerTest extends TestCase
     public function test_show_404_when_missing(): void
     {
         $u = User::factory()->create();
-        $this->grant($u, ['predefinedFilter.view'=>'1']);
+        $this->grant($u, ['predefinedFilter.view' => '1']);
 
         $this->actingAs($u, 'api')
             ->getJson('/api/v1/predefinedFilters/999999')
             ->assertStatus(404)
             ->assertJson(['message' => 'Filter does not exist.']);
     }
-    
-    public function test_show_forbidden_without_view_permission(): void 
+
+    public function test_show_forbidden_without_view_permission(): void
     {
         $user = User::factory()->create();
         $owner = User::factory()->create();
@@ -156,13 +162,13 @@ class PredefinedFilterControllerTest extends TestCase
         $u = User::factory()->create();
         $f = PredefinedFilter::factory()->create([
             'created_by' => $u->id,
-            'is_public'  => 0,
+            'is_public' => 0,
         ]);
 
         $this->actingAs($u, 'api')
             ->getJson("/api/v1/predefinedFilters/{$f->id}")
             ->assertOk()
-            ->assertJsonFragment(['id'=>$f->id,'name'=>$f->name]);
+            ->assertJsonFragment(['id' => $f->id, 'name' => $f->name]);
     }
 
     public function test_show_forbidden_without_view_or_not_public()
@@ -196,7 +202,7 @@ class PredefinedFilterControllerTest extends TestCase
         $this->actingAs($u, 'api')
             ->getJson("/api/v1/predefinedFilters/{$f->id}")
             ->assertOk()
-            ->assertJsonFragment(['id' => $f->id, 'name'=> $f->name]);
+            ->assertJsonFragment(['id' => $f->id, 'name' => $f->name]);
     }
 
     public function test_show_forbidden_when_private_and_not_owner(): void
@@ -205,60 +211,60 @@ class PredefinedFilterControllerTest extends TestCase
         $owner = User::factory()->create();
 
         $filter = PredefinedFilter::factory()->create([
-            'created_by'=>$owner->id,
-            'is_public'=>0,
+            'created_by' => $owner->id,
+            'is_public' => 0,
         ]);
 
-        $this->actingAs($userWithout,'api')
+        $this->actingAs($userWithout, 'api')
             ->getJson("/api/v1/predefinedFilters/{$filter->id}")
             ->assertStatus(403)
-            ->assertJson(['message'=>trans('admin/predefinedFilters/message.show.not_allowed')]);
+            ->assertJson(['message' => trans('admin/predefinedFilters/message.show.not_allowed')]);
     }
 
     public function test_show_non_owner_public_with_view_is_ok(): void
     {
         $owner = User::factory()->create();
-        $user  = User::factory()->create();
-        $g = $this->grant($user, ['predefinedFilter.view'=>'1']);
+        $user = User::factory()->create();
+        $g = $this->grant($user, ['predefinedFilter.view' => '1']);
 
         $filter = PredefinedFilter::factory()->create([
-            'name'=>'Allowed Public Filter',
-            'created_by'=>$owner->id,
-            'is_public'=>1,
+            'name' => 'Allowed Public Filter',
+            'created_by' => $owner->id,
+            'is_public' => 1,
         ]);
-        $this->linkGroupFilter($filter,$g);
+        $this->linkGroupFilter($filter, $g);
 
-        $this->actingAs($user,'api')
+        $this->actingAs($user, 'api')
             ->getJson("/api/v1/predefinedFilters/{$filter->id}")
             ->assertOk()
-            ->assertJsonFragment(['name'=>'Allowed Public Filter']);
+            ->assertJsonFragment(['name' => 'Allowed Public Filter']);
     }
 
     public function test_show_forbidden_for_private_non_owner(): void
     {
         $owner = User::factory()->create();
-        $user  = User::factory()->create();
+        $user = User::factory()->create();
 
         $filter = PredefinedFilter::factory()->create([
-            'name'=>'Private Filter',
-            'created_by'=>$owner->id,
-            'is_public'=>0,
+            'name' => 'Private Filter',
+            'created_by' => $owner->id,
+            'is_public' => 0,
         ]);
 
-        $this->actingAs($user,'api')
+        $this->actingAs($user, 'api')
             ->getJson("/api/v1/predefinedFilters/{$filter->id}")
             ->assertStatus(403)
-            ->assertJson(['message'=>trans('admin/predefinedFilters/message.show.not_allowed')]);
+            ->assertJson(['message' => trans('admin/predefinedFilters/message.show.not_allowed')]);
     }
 
     public function test_show_returns_404_if_filter_not_found(): void
     {
         $user = User::factory()->create();
 
-        $this->actingAs($user,'api')
+        $this->actingAs($user, 'api')
             ->getJson('/api/v1/predefinedFilters/404')
             ->assertStatus(404)
-            ->assertJson(['message'=>trans('admin/predefinedFilters/message.does_not_exist')]);
+            ->assertJson(['message' => trans('admin/predefinedFilters/message.does_not_exist')]);
     }
 
 
@@ -276,22 +282,22 @@ class PredefinedFilterControllerTest extends TestCase
     }
 
 
-    public function test_store_creates_and_sets_owner() 
+    public function test_store_creates_and_sets_owner()
     {
         $u = User::factory()->create();
         $this->grant($u, ['predefinedFilter.create' => '1']);
 
         $this->actingAs($u, 'api')
             ->postJson(route('api.predefined-filters.store'), [
-                'name'        => 'Neu',
+                'name' => 'Neu',
                 'filter_data' => ['status_id' => [1, 2]],
-                'is_public'   => 1,
-                'created_by'  => 999,
+                'is_public' => 1,
+                'created_by' => 999,
             ])
-        ->assertCreated()
-        ->assertJsonPath('filter_data.name', 'Neu')
-        ->assertJsonPath('filter_data.is_public', true)
-        ->assertJsonPath('filter_data.created_by', $u->id);
+            ->assertCreated()
+            ->assertJsonPath('filter_data.name', 'Neu')
+            ->assertJsonPath('filter_data.is_public', true)
+            ->assertJsonPath('filter_data.created_by', $u->id);
     }
 
     public function test_store_public_requires_create_permission()
@@ -299,29 +305,29 @@ class PredefinedFilterControllerTest extends TestCase
         $u = User::factory()->create();
 
         $this->actingAs($u, 'api')
-            ->postJson(route('api.predefined-filters.store'),[
-                'name'  => 'X',
+            ->postJson(route('api.predefined-filters.store'), [
+                'name' => 'X',
                 'filter_data' => ['a' => 1],
                 'is_public' => 1,
             ])
-        ->assertStatus(403)
-        ->assertJson(['message' => trans('admin/predefinedFilters/message.create.not_allowed')]);
+            ->assertStatus(403)
+            ->assertJson(['message' => trans('admin/predefinedFilters/message.create.not_allowed')]);
     }
     public function test_store_public_with_create_permission_returns_201(): void
     {
         $user = User::factory()->create();
-        $this->grant($user, ['predefinedFilter.create'=>'1']);
+        $this->grant($user, ['predefinedFilter.create' => '1']);
 
         $payload = [
-            'name'=>'Test Public Filter',
-            'filter_data'=>['status_id'=>[1]],
-            'is_public'=>true,
+            'name' => 'Test Public Filter',
+            'filter_data' => ['status_id' => [1]],
+            'is_public' => true,
         ];
 
-        $this->actingAs($user,'api')
+        $this->actingAs($user, 'api')
             ->postJson('/api/v1/predefinedFilters', $payload)
             ->assertCreated()
-            ->assertJsonPath('filter_data.name','Test Public Filter')
+            ->assertJsonPath('filter_data.name', 'Test Public Filter')
             ->assertJsonPath('filter_data.is_public', true)
             ->assertJsonPath('filter_data.created_by', $user->id);
     }
@@ -331,15 +337,15 @@ class PredefinedFilterControllerTest extends TestCase
         $user = User::factory()->create();
 
         $payload = [
-            'name'=>'Unauthorized Public Filter',
-            'filter_data'=>['status_id'=>[1]],
-            'is_public'=>true,
+            'name' => 'Unauthorized Public Filter',
+            'filter_data' => ['status_id' => [1]],
+            'is_public' => true,
         ];
 
-        $this->actingAs($user,'api')
+        $this->actingAs($user, 'api')
             ->postJson('/api/v1/predefinedFilters', $payload)
             ->assertStatus(403)
-            ->assertJson(['message'=>trans('admin/predefinedFilters/message.create.not_allowed')]);
+            ->assertJson(['message' => trans('admin/predefinedFilters/message.create.not_allowed')]);
     }
 
     //------UPDATE TESTS------
@@ -349,14 +355,16 @@ class PredefinedFilterControllerTest extends TestCase
         $u = User::factory()->create();
         $f = PredefinedFilter::factory()->create([
             'created_by' => $u->id,
-            'is_public'  => 0,
-            'name'       => 'Old',
-            'filter_data'=> ['a' => 1],
+            'is_public' => 0,
+            'name' => 'Old',
+            'filter_data' => ['a' => 1],
         ]);
 
         $this->actingAs($u, 'api')
             ->putJson("/api/v1/predefinedFilters/{$f->id}", [
-                'name'=>'New','filter_data'=>['a'=>2],'is_public'=>1
+                'name' => 'New',
+                'filter_data' => ['a' => 2],
+                'is_public' => 1
             ])
             ->assertStatus(403);
 
@@ -365,11 +373,13 @@ class PredefinedFilterControllerTest extends TestCase
 
         $this->actingAs($u->fresh(), 'api')
             ->putJson("/api/v1/predefinedFilters/{$f->id}", [
-                'name'=>'New','filter_data'=>['a'=>2],'is_public'=>1
+                'name' => 'New',
+                'filter_data' => ['a' => 2],
+                'is_public' => 1
             ])
-        ->assertOk()
-        ->assertJsonPath('filter_data.is_public', true)
-        ->assertJsonPath('filter_data.name', 'New');
+            ->assertOk()
+            ->assertJsonPath('filter_data.is_public', true)
+            ->assertJsonPath('filter_data.name', 'New');
     }
 
     public function test_update_non_owner_public_requires_update_permission(): void
@@ -379,36 +389,42 @@ class PredefinedFilterControllerTest extends TestCase
 
         $f = PredefinedFilter::factory()->create([
             'created_by' => $owner->id,
-            'is_public'  => 1,
-            'name'       => 'Old',
-            'filter_data'=> ['a' => 1],
+            'is_public' => 1,
+            'name' => 'Old',
+            'filter_data' => ['a' => 1],
         ]);
 
         $this->actingAs($other, 'api')
             ->putJson("/api/v1/predefinedFilters/{$f->id}", [
-                'name'=>'X','filter_data'=>['a'=>3],'is_public'=>1
+                'name' => 'X',
+                'filter_data' => ['a' => 3],
+                'is_public' => 1
             ])
             ->assertStatus(403);
-            
-        $g = $this->grant($other, ['predefinedFilter.edit'=>'1']);
+
+        $g = $this->grant($other, ['predefinedFilter.edit' => '1']);
         $this->linkGroupFilter($f, $g);
-            
+
         $this->actingAs($other, 'api')
             ->putJson("/api/v1/predefinedFilters/{$f->id}", [
-                'name'=>'X','filter_data'=>['a'=>3],'is_public'=>1
+                'name' => 'X',
+                'filter_data' => ['a' => 3],
+                'is_public' => 1
             ])
-        ->assertOk()
-        ->assertJsonPath('filter_data.name','X');
+            ->assertOk()
+            ->assertJsonPath('filter_data.name', 'X');
     }
     public function test_update_404_when_missing(): void
     {
         $u = User::factory()->create();
         $this->actingAs($u, 'api')
             ->putJson('/api/v1/predefinedFilters/999999', [
-                'name' => 'X', 'filter_data' => [], 'is_public' => 0
+                'name' => 'X',
+                'filter_data' => [],
+                'is_public' => 0
             ])
-        ->assertStatus(404)
-        ->assertJson(['message' => 'Filter does not exist.']);
+            ->assertStatus(404)
+            ->assertJson(['message' => 'Filter does not exist.']);
     }
 
     public function test_update_validates_payload(): void
@@ -418,7 +434,7 @@ class PredefinedFilterControllerTest extends TestCase
 
         $this->actingAs($u, 'api')
             ->putJson(route('api.predefined-filters.update', ['id' => $f->id]), []);
-        
+
         $this->actingAs($u, 'api')
             ->putJson(route('api.predefined-filters.update', ['id' => $f->id]), [])
             ->assertStatus(422)
@@ -426,55 +442,55 @@ class PredefinedFilterControllerTest extends TestCase
             ->assertJsonPath('messages.filter_data.0', 'The filter data field is required.');
     }
 
-//------DESTROY TESTS------
-public function test_destroy_non_owner_public_requires_destroy_permission()
-{
-    $owner = User::factory()->create();
-    $other = User::factory()->create();
+    //------DESTROY TESTS------
+    public function test_destroy_non_owner_public_requires_destroy_permission()
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
 
-    $f = PredefinedFilter::factory()->create([
-        'created_by' => $owner->id,
-        'is_public'  => 1,
-    ]);
-
-    $this->actingAs($other, 'api')
-        ->deleteJson("/api/v1/predefinedFilters/{$f->id}")
-        ->assertStatus(403);
-
-    $g = $this->grant($other, ['predefinedFilter.delete' => '1']);
-    $this->linkGroupFilter($f, $g);
-
-    $this->actingAs($other, 'api')
-        ->deleteJson("/api/v1/predefinedFilters/{$f->id}")
-        ->assertOk()
-        ->assertJson([
-            'message' => trans('admin/predefinedFilters/message.delete.success'),
+        $f = PredefinedFilter::factory()->create([
+            'created_by' => $owner->id,
+            'is_public' => 1,
         ]);
 
-    $this->assertSoftDeleted('predefined_filters', ['id' => $f->id]);
-}
+        $this->actingAs($other, 'api')
+            ->deleteJson("/api/v1/predefinedFilters/{$f->id}")
+            ->assertStatus(403);
 
-    public function test_destroy_404_when_missing() 
+        $g = $this->grant($other, ['predefinedFilter.delete' => '1']);
+        $this->linkGroupFilter($f, $g);
+
+        $this->actingAs($other, 'api')
+            ->deleteJson("/api/v1/predefinedFilters/{$f->id}")
+            ->assertOk()
+            ->assertJson([
+                'message' => trans('admin/predefinedFilters/message.delete.success'),
+            ]);
+
+        $this->assertSoftDeleted('predefined_filters', ['id' => $f->id]);
+    }
+
+    public function test_destroy_404_when_missing()
     {
         $u = User::factory()->create();
 
         $this->actingAs($u, 'api')
             ->deleteJson('/api/v1/predefinedFilters/999999')
             ->assertStatus(404)
-            ->assertJson(['message'=>trans('admin/predefinedFilters/message.does_not_exist')]);
+            ->assertJson(['message' => trans('admin/predefinedFilters/message.does_not_exist')]);
     }
 
-    public function test_destroy_owner_private_ok_200() 
+    public function test_destroy_owner_private_ok_200()
     {
-    $u = User::factory()->create();
-    $f = PredefinedFilter::factory()->create(['created_by'=>$u->id,'is_public'=>0, 'filter_data'=>[['a'=>'a']]]);
+        $u = User::factory()->create();
+        $f = PredefinedFilter::factory()->create(['created_by' => $u->id, 'is_public' => 0, 'filter_data' => [['a' => 'a']]]);
 
-    $this->actingAs($u, 'api')
-        ->deleteJson("/api/v1/predefinedFilters/{$f->id}")
-        ->assertOk()
-        ->assertJson(['message'=>trans('admin/predefinedFilters/message.delete.success')]);
+        $this->actingAs($u, 'api')
+            ->deleteJson("/api/v1/predefinedFilters/{$f->id}")
+            ->assertOk()
+            ->assertJson(['message' => trans('admin/predefinedFilters/message.delete.success')]);
 
-    $this->assertSoftDeleted('predefined_filters', ['id' => $f->id]);
+        $this->assertSoftDeleted('predefined_filters', ['id' => $f->id]);
     }
 
     // PermissionStructureTests
@@ -607,6 +623,97 @@ public function test_destroy_non_owner_public_requires_destroy_permission()
         $this->assertArrayHasKey('created_at', $result);
         $this->assertArrayHasKey('updated_at', $result);
         $this->assertArrayHasKey('deleted_at', $result);
+    }
+
+    //------SELECTLIST TESTS------
+
+    public function test_selectlist()
+    {
+        $owner = User::factory()->create();
+        $grant = $this->grant($owner, ['predefinedFilter.view' => '1', 'predefinedFilter.create' => '1', 'predefinedFilter.edit' => '1']);
+
+        $publicFilterA = PredefinedFilter::factory()->create([
+            'name' => 'All coffee machines',
+            'created_by' => $owner->id,
+            'is_public' => 1,
+        ]);
+
+        $publicFilterB = PredefinedFilter::factory()->create([
+            'name' => 'Desktops',
+            'created_by' => $owner->id,
+            'is_public' => 1,
+        ]);
+
+        $privateFilterA = PredefinedFilter::factory()->create([
+            'name' => 'Laptops',
+            'created_by' => $owner->id,
+            'is_public' => 0,
+        ]);
+
+        $privateFilterB = PredefinedFilter::factory()->create([
+            'name' => 'Coffee mugs',
+            'created_by' => $owner->id,
+            'is_public' => 0,
+        ]);
+
+        $this->linkGroupFilter($publicFilterA, $grant);
+        $this->linkGroupFilter($publicFilterB, $grant);
+
+        $response = $this->actingAs($owner, 'api')
+            ->getJson('/api/v1/predefinedFilters/selectlist');
+
+        $response->assertOk()
+            ->assertJsonFragment(['id' => $publicFilterA->id, 'name' => $publicFilterA->name])
+            ->assertJsonFragment(['id' => $publicFilterB->id, 'name' => $publicFilterB->name])
+            ->assertJsonFragment(['id' => $privateFilterA->id, 'name' => $privateFilterA->name])
+            ->assertJsonFragment(['id' => $privateFilterB->id, 'name' => $privateFilterB->name]);
+
+        $this->assertCount(4, $response->json('rows'));
+    }
+
+    public function test_selectlist_search()
+    {
+        $owner = User::factory()->create();
+        $grant = $this->grant($owner, ['predefinedFilter.view' => '1']);
+
+        $publicFilterA = PredefinedFilter::factory()->create([
+            'name' => 'All coffee machines',
+            'created_by' => $owner->id,
+            'is_public' => 1,
+        ]);
+
+        $publicFilterB = PredefinedFilter::factory()->create([
+            'name' => 'Desktops',
+            'created_by' => $owner->id,
+            'is_public' => 1,
+        ]);
+
+        $privateFilterA = PredefinedFilter::factory()->create([
+            'name' => 'Laptops',
+            'created_by' => $owner->id,
+            'is_public' => 0,
+        ]);
+
+        $privateFilterB = PredefinedFilter::factory()->create([
+            'name' => 'Coffee mugs',
+            'created_by' => $owner->id,
+            'is_public' => 0,
+        ]);
+
+        $this->linkGroupFilter($publicFilterA, $grant);
+        $this->linkGroupFilter($publicFilterB, $grant);
+
+        $response = $this->actingAs($owner, 'api')
+            ->getJson('/api/v1/predefinedFilters/selectlist', [
+                'search' => 'coffee',
+                'page' => 1,
+            ]);
+
+        $response->assertOk()
+            ->assertJsonFragment(['id' => $publicFilterA->id, 'name' => $publicFilterA->name])
+            ->assertJsonFragment(['id' => $privateFilterB->id, 'name' => $privateFilterB->name]);
+
+        $this->assertCount(2, $response->json('rows'));
     }
 
 }

--- a/tests/Feature/PredefinedFilter/Api/PredefinedFilterControllerTest.php
+++ b/tests/Feature/PredefinedFilter/Api/PredefinedFilterControllerTest.php
@@ -663,12 +663,12 @@ class PredefinedFilterControllerTest extends TestCase
             ->getJson('/api/v1/predefinedFilters/selectlist');
 
         $response->assertOk()
-            ->assertJsonFragment(['id' => $publicFilterA->id, 'name' => $publicFilterA->name])
-            ->assertJsonFragment(['id' => $publicFilterB->id, 'name' => $publicFilterB->name])
-            ->assertJsonFragment(['id' => $privateFilterA->id, 'name' => $privateFilterA->name])
-            ->assertJsonFragment(['id' => $privateFilterB->id, 'name' => $privateFilterB->name]);
+            ->assertJsonFragment(['id' => $publicFilterA->id, 'text' => $publicFilterA->name . " (Public)"])
+            ->assertJsonFragment(['id' => $publicFilterB->id, 'text' => $publicFilterB->name . " (Public)"])
+            ->assertJsonFragment(['id' => $privateFilterA->id, 'text' => $privateFilterA->name . " (Private)"])
+            ->assertJsonFragment(['id' => $privateFilterB->id, 'text' => $privateFilterB->name . " (Private)"]);
 
-        $this->assertCount(4, $response->json('rows'));
+        $this->assertCount(4, $response->json('results'));
     }
 
     public function test_selectlist_search()
@@ -704,16 +704,179 @@ class PredefinedFilterControllerTest extends TestCase
         $this->linkGroupFilter($publicFilterB, $grant);
 
         $response = $this->actingAs($owner, 'api')
-            ->getJson('/api/v1/predefinedFilters/selectlist', [
-                'search' => 'coffee',
-                'page' => 1,
-            ]);
+            ->getJson('/api/v1/predefinedFilters/selectlist?search=coffee&page=1');
 
         $response->assertOk()
-            ->assertJsonFragment(['id' => $publicFilterA->id, 'name' => $publicFilterA->name])
-            ->assertJsonFragment(['id' => $privateFilterB->id, 'name' => $privateFilterB->name]);
+            ->assertJsonFragment(['id' => $publicFilterA->id, 'text' => $publicFilterA->name . " (Public)"])
+            ->assertJsonFragment(['id' => $privateFilterB->id, 'text' => $privateFilterB->name . " (Private)"]);
 
-        $this->assertCount(2, $response->json('rows'));
+        $this->assertCount(2, $response->json('results'));
+    }
+
+    public function test_selectlist_private()
+    {
+        $owner = User::factory()->create();
+        $grant = $this->grant($owner, ['predefinedFilter.view' => '1']);
+
+        $publicFilterA = PredefinedFilter::factory()->create([
+            'name' => 'All coffee machines',
+            'created_by' => $owner->id,
+            'is_public' => 1,
+        ]);
+
+        $publicFilterB = PredefinedFilter::factory()->create([
+            'name' => 'Desktops',
+            'created_by' => $owner->id,
+            'is_public' => 1,
+        ]);
+
+        $privateFilterA = PredefinedFilter::factory()->create([
+            'name' => 'Laptops',
+            'created_by' => $owner->id,
+            'is_public' => 0,
+        ]);
+
+        $privateFilterB = PredefinedFilter::factory()->create([
+            'name' => 'Coffee mugs',
+            'created_by' => $owner->id,
+            'is_public' => 0,
+        ]);
+
+        $this->linkGroupFilter($publicFilterA, $grant);
+        $this->linkGroupFilter($publicFilterB, $grant);
+
+        $response = $this->actingAs($owner, 'api')
+            ->getJson('/api/v1/predefinedFilters/selectlist?search=PRIVATE:&page=1');
+
+        $response->assertOk()
+            ->assertJsonFragment(['id' => $privateFilterA->id, 'text' => $privateFilterA->name . " (Private)"])
+            ->assertJsonFragment(['id' => $privateFilterB->id, 'text' => $privateFilterB->name . " (Private)"]);
+
+        $this->assertCount(2, $response->json('results'));
+    }
+
+    public function test_selectlist_public()
+    {
+        $owner = User::factory()->create();
+        $grant = $this->grant($owner, ['predefinedFilter.view' => '1']);
+
+        $publicFilterA = PredefinedFilter::factory()->create([
+            'name' => 'All coffee machines',
+            'created_by' => $owner->id,
+            'is_public' => 1,
+        ]);
+
+        $publicFilterB = PredefinedFilter::factory()->create([
+            'name' => 'Desktops',
+            'created_by' => $owner->id,
+            'is_public' => 1,
+        ]);
+
+        $privateFilterA = PredefinedFilter::factory()->create([
+            'name' => 'Laptops',
+            'created_by' => $owner->id,
+            'is_public' => 0,
+        ]);
+
+        $privateFilterB = PredefinedFilter::factory()->create([
+            'name' => 'Coffee mugs',
+            'created_by' => $owner->id,
+            'is_public' => 0,
+        ]);
+
+        $this->linkGroupFilter($publicFilterA, $grant);
+        $this->linkGroupFilter($publicFilterB, $grant);
+
+        $response = $this->actingAs($owner, 'api')
+            ->getJson('/api/v1/predefinedFilters/selectlist?search=PUBLIC:&page=1');
+
+        $response->assertOk()
+            ->assertJsonFragment(['id' => $publicFilterA->id, 'text' => $publicFilterA->name . " (Public)"])
+            ->assertJsonFragment(['id' => $publicFilterB->id, 'text' => $publicFilterB->name . " (Public)"]);
+
+        $this->assertCount(2, $response->json('results'));
+    }
+
+    public function test_selectlist_private_search()
+    {
+        $owner = User::factory()->create();
+        $grant = $this->grant($owner, ['predefinedFilter.view' => '1']);
+
+        $publicFilterA = PredefinedFilter::factory()->create([
+            'name' => 'All coffee machines',
+            'created_by' => $owner->id,
+            'is_public' => 1,
+        ]);
+
+        $publicFilterB = PredefinedFilter::factory()->create([
+            'name' => 'Desktops',
+            'created_by' => $owner->id,
+            'is_public' => 1,
+        ]);
+
+        $privateFilterA = PredefinedFilter::factory()->create([
+            'name' => 'Laptops',
+            'created_by' => $owner->id,
+            'is_public' => 0,
+        ]);
+
+        $privateFilterB = PredefinedFilter::factory()->create([
+            'name' => 'Coffee mugs',
+            'created_by' => $owner->id,
+            'is_public' => 0,
+        ]);
+
+        $this->linkGroupFilter($publicFilterA, $grant);
+        $this->linkGroupFilter($publicFilterB, $grant);
+
+        $response = $this->actingAs($owner, 'api')
+            ->getJson('/api/v1/predefinedFilters/selectlist?search=PRIVATE: Laptop&page=1');
+
+        $response->assertOk()
+            ->assertJsonFragment(['id' => $privateFilterA->id, 'text' => $privateFilterA->name . " (Private)"]);
+
+        $this->assertCount(1, $response->json('results'));
+    }
+
+    public function test_selectlist_public_search()
+    {
+        $owner = User::factory()->create();
+        $grant = $this->grant($owner, ['predefinedFilter.view' => '1']);
+
+        $publicFilterA = PredefinedFilter::factory()->create([
+            'name' => 'All coffee machines',
+            'created_by' => $owner->id,
+            'is_public' => 1,
+        ]);
+
+        $publicFilterB = PredefinedFilter::factory()->create([
+            'name' => 'Desktops',
+            'created_by' => $owner->id,
+            'is_public' => 1,
+        ]);
+
+        $privateFilterA = PredefinedFilter::factory()->create([
+            'name' => 'Laptops',
+            'created_by' => $owner->id,
+            'is_public' => 0,
+        ]);
+
+        $privateFilterB = PredefinedFilter::factory()->create([
+            'name' => 'Coffee mugs',
+            'created_by' => $owner->id,
+            'is_public' => 0,
+        ]);
+
+        $this->linkGroupFilter($publicFilterA, $grant);
+        $this->linkGroupFilter($publicFilterB, $grant);
+
+        $response = $this->actingAs($owner, 'api')
+            ->getJson('/api/v1/predefinedFilters/selectlist?search=PUBLIC: coffee&page=1');
+
+        $response->assertOk()
+            ->assertJsonFragment(['id' => $publicFilterA->id, 'text' => $publicFilterA->name . " (Public)"]);
+
+        $this->assertCount(1, $response->json('results'));
     }
 
 }


### PR DESCRIPTION
You can write _PRIVATE:_ or _PUBLIC:_ (or the version of that in your language) before the search-field for the predefined filters to filter after private or public ones.